### PR TITLE
#8 Add ability to configure labels used

### DIFF
--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -115,7 +115,7 @@ jobs:
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
           repository: AbsaOSS/organizational-workflows
-          ref: master
+          ref: feature/8-ability-to-configure-labels-used
           path: org-workflows
           persist-credentials: false
 

--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -105,6 +105,12 @@ jobs:
     needs: aquasec-scan
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
+        with:
+          persist-credentials: false
+          path: caller-repo
+
       - name: Checkout security scripts
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8
         with:
@@ -131,4 +137,11 @@ jobs:
           PROJECT_NUMBER: ${{ inputs.project-number }}
           PROJECT_ORG: ${{ inputs.project-org }}
         run: |
-          org-workflows/github/security/sync_security_alerts.sh
+          SYNC_ARGS=()
+          # If the caller repo ships a .github/labels.yml, use it to override
+          # the default label names.
+          CALLER_LABELS="caller-repo/.github/labels.yml"
+          if [[ -f "$CALLER_LABELS" ]]; then
+            SYNC_ARGS+=(--label-config "$CALLER_LABELS")
+          fi
+          org-workflows/github/security/sync_security_alerts.sh "${SYNC_ARGS[@]}"

--- a/github/security/README.md
+++ b/github/security/README.md
@@ -17,6 +17,7 @@ In one sentence: SARIF uploads create alerts; these scripts sync alerts into Iss
   - [How to adopt a shared workflow](#how-to-adopt-a-shared-workflow)
     - [Aquasec Night Scan](#aquasec-night-scan)
     - [Remove sec:adept-to-close on close](#remove-secadept-to-close-on-close)
+- [Label configuration](#label-configuration)
 - [Labels (contract)](#labels-contract)
 - [Issue metadata (secmeta)](#issue-metadata-secmeta)
 - [Issue structure](#issue-structure)
@@ -41,6 +42,7 @@ In one sentence: SARIF uploads create alerts; these scripts sync alerts into Iss
 | `check_labels.sh` | Verify that all labels required by the automation exist in the repository | `gh` |
 | `collect_alert.sh` | Fetch and normalize code scanning alerts into `alerts.json` | `gh`, `jq` |
 | `promote_alerts.py` | Create/update parent+child Issues from `alerts.json` and link children under parents | `gh` |
+| `labels.yml` | Label configuration: maps logical label purposes to actual GitHub label names | — |
 | `send_to_teams.py` | Send a Markdown message to a Microsoft Teams channel via Incoming Webhook | `requests` |
 | `extract_team_security_stats.py` | Snapshot security Issues for a team across repos | `PyGithub`, `GITHUB_TOKEN` |
 | `derive_team_security_metrics.py` | Compute metrics/deltas from snapshots | stdlib |
@@ -205,41 +207,170 @@ jobs:
 
 > **Note:** The calling repository must grant the permissions the reusable workflow needs (listed in each workflow file). For cross-organization calls the reusable workflow repository must be set to "Accessible from repositories in the organization" under **Settings → Actions → General**.
 
+## Label configuration
+
+The four core labels used by the automation pipeline are **configurable** via a `labels.yml` file placed in the `github/security/` directory (next to the scripts). This lets each consuming repository map the logical label purposes to its own label names.
+
+### Default `labels.yml`
+
+```yaml
+# Core
+scope_security: "scope:security"
+type_tech_debt: "type:tech-debt"
+epic: "epic"
+
+# Lifecycle
+adept_to_close: "sec:adept-to-close"
+
+# Source
+src_aquasec_sarif: "sec:src/aquasec-sarif"
+
+# State
+state_postponed: "sec:state/postponed"
+state_needs_review: "sec:state/needs-review"
+
+# Severity
+sev_critical: "sec:sev/critical"
+sev_high: "sec:sev/high"
+sev_medium: "sec:sev/medium"
+sev_low: "sec:sev/low"
+
+# Closure reasons
+close_fixed: "sec:close/fixed"
+close_false_positive: "sec:close/false-positive"
+close_accepted_risk: "sec:close/accepted-risk"
+close_not_applicable: "sec:close/not-applicable"
+
+# Postpone reasons
+postpone_vendor: "sec:postpone/vendor"
+postpone_platform: "sec:postpone/platform"
+postpone_roadmap: "sec:postpone/roadmap"
+postpone_other: "sec:postpone/other"
+```
+
+### Customising labels
+
+To override any label, edit `labels.yml` in your copy of the scripts (or provide a path at runtime). For example, if your repository uses `type:epic` instead of `epic`:
+
+```yaml
+epic: "type:epic"
+```
+
+Only the keys you include are overridden; missing keys fall back to the built-in defaults shown above.
+
+### Passing a custom config path
+
+All three entrypoints accept a `--label-config` flag:
+
+```bash
+# Shell wrapper
+./sync_security_alerts.sh --repo my-org/my-repo --label-config /path/to/labels.yml
+
+# Label check only
+./check_labels.sh --repo my-org/my-repo --label-config /path/to/labels.yml
+
+# Python promote step
+python3 promote_alerts.py --file alerts.json --label-config /path/to/labels.yml
+```
+
+When `--label-config` is omitted, the scripts look for `labels.yml` in their own directory. If that file is absent, built-in defaults are used (identical to the table above).
+
+### Configurable keys
+
+#### Core (applied by the pipeline)
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `scope_security` | `scope:security` | Applied to every security issue; used to mine existing issues |
+| `type_tech_debt` | `type:tech-debt` | Applied to every security issue |
+| `epic` | `epic` | Applied to parent (grouping) issues |
+| `adept_to_close` | `sec:adept-to-close` | Applied to orphan child issues that no longer have a matching alert |
+
+#### Source
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `src_aquasec_sarif` | `sec:src/aquasec-sarif` | Identifies the scan source |
+
+#### State
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `state_postponed` | `sec:state/postponed` | Issue has been postponed |
+| `state_needs_review` | `sec:state/needs-review` | Issue needs manual review |
+
+#### Severity
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `sev_critical` | `sec:sev/critical` | Critical severity |
+| `sev_high` | `sec:sev/high` | High severity |
+| `sev_medium` | `sec:sev/medium` | Medium severity |
+| `sev_low` | `sec:sev/low` | Low severity |
+
+#### Closure reasons
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `close_fixed` | `sec:close/fixed` | Fixed in code |
+| `close_false_positive` | `sec:close/false-positive` | Not a real finding |
+| `close_accepted_risk` | `sec:close/accepted-risk` | Risk acknowledged |
+| `close_not_applicable` | `sec:close/not-applicable` | Not applicable to this repo |
+
+#### Postpone reasons
+
+| Key | Default value | Purpose |
+| --- | --- | --- |
+| `postpone_vendor` | `sec:postpone/vendor` | Waiting on vendor fix |
+| `postpone_platform` | `sec:postpone/platform` | Platform constraint |
+| `postpone_roadmap` | `sec:postpone/roadmap` | Scheduled for a later milestone |
+| `postpone_other` | `sec:postpone/other` | Other reason (detail in comment) |
+
 ## Labels (contract)
 
-This repository contains multiple scripts with different “label contracts”:
+All label names used by this automation are configurable via `labels.yml` (see [Label configuration](#label-configuration) above). The values below are the **defaults**.
 
 - `promote_alerts.py` mines existing issues by `--issue-label` (default: `scope:security`) and ensures baseline labels `scope:security` and `type:tech-debt` on child/parent issues it creates/updates.
 
 ### Source
 
-- `sec:src/aquasec-sarif`
+| Config key | Default label |
+| --- | --- |
+| `src_aquasec_sarif` | `sec:src/aquasec-sarif` |
 
 ### State
 
-- `sec:state/postponed`
-- `sec:state/needs-review`
+| Config key | Default label |
+| --- | --- |
+| `state_postponed` | `sec:state/postponed` |
+| `state_needs_review` | `sec:state/needs-review` |
 
 ### Severity
 
-- `sec:sev/critical`
-- `sec:sev/high`
-- `sec:sev/medium`
-- `sec:sev/low`
+| Config key | Default label |
+| --- | --- |
+| `sev_critical` | `sec:sev/critical` |
+| `sev_high` | `sec:sev/high` |
+| `sev_medium` | `sec:sev/medium` |
+| `sev_low` | `sec:sev/low` |
 
 ### Closure reasons
 
-- `sec:close/fixed`
-- `sec:close/false-positive`
-- `sec:close/accepted-risk`
-- `sec:close/not-applicable`
+| Config key | Default label |
+| --- | --- |
+| `close_fixed` | `sec:close/fixed` |
+| `close_false_positive` | `sec:close/false-positive` |
+| `close_accepted_risk` | `sec:close/accepted-risk` |
+| `close_not_applicable` | `sec:close/not-applicable` |
 
 ### Postpone reasons
 
-- `sec:postpone/vendor`
-- `sec:postpone/platform`
-- `sec:postpone/roadmap`
-- `sec:postpone/other`
+| Config key | Default label |
+| --- | --- |
+| `postpone_vendor` | `sec:postpone/vendor` |
+| `postpone_platform` | `sec:postpone/platform` |
+| `postpone_roadmap` | `sec:postpone/roadmap` |
+| `postpone_other` | `sec:postpone/other` |
 
 ## Issue metadata (secmeta)
 

--- a/github/security/check_labels.sh
+++ b/github/security/check_labels.sh
@@ -15,25 +15,33 @@
 # limitations under the License.
 #
 # Check that required labels exist in a GitHub repo using gh + jq.
+# Labels are loaded from labels.yml when available; otherwise built-in
+# defaults are used.
+#
 # Usage:
 #   ./check_labels.sh --repo owner/repo
+#   ./check_labels.sh --repo owner/repo --label-config /path/to/labels.yml
 
 set -euo pipefail
 
-REQUIRED_LABELS=(
-  "scope:security"
-  "type:tech-debt"
-  "epic"
-  "sec:adept-to-close"
-)
+# -- Built-in defaults (same as labels.yml ships with) --------------------
+_DEFAULT_SCOPE_SECURITY="scope:security"
+_DEFAULT_TYPE_TECH_DEBT="type:tech-debt"
+_DEFAULT_EPIC="epic"
+_DEFAULT_ADEPT_TO_CLOSE="sec:adept-to-close"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LABEL_CONFIG=""
 
 repo=""
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --repo)
       repo="${2:-}"; shift 2;;
+    --label-config)
+      LABEL_CONFIG="${2:-}"; shift 2;;
     -h|--help)
-      echo "Usage: $0 --repo owner/repo"; exit 0;;
+      echo "Usage: $0 --repo owner/repo [--label-config path/to/labels.yml]"; exit 0;;
     *)
       echo "Unknown argument: $1" >&2; exit 2;;
   esac
@@ -43,6 +51,36 @@ if [[ -z "$repo" ]]; then
   echo "ERROR: --repo owner/repo is required" >&2
   exit 2
 fi
+
+if [[ -z "$LABEL_CONFIG" ]]; then
+  LABEL_CONFIG="$SCRIPT_DIR/labels.yml"
+fi
+
+# Helper: read a value from the flat YAML config 
+# Usage: _cfg_val <key> <default>
+_cfg_val() {
+  local key="$1" default="$2"
+  if [[ ! -f "$LABEL_CONFIG" ]]; then
+    printf '%s' "$default"
+    return
+  fi
+
+  local val
+  val="$(grep -E "^${key}\s*:" "$LABEL_CONFIG" 2>/dev/null | head -1 \
+       | sed -E 's/^[^:]+:\s*//; s/^["'"'"']//; s/["'"'"']\s*(#.*)?$//; s/\s*#.*$//' )" || true
+  if [[ -n "$val" ]]; then
+    printf '%s' "$val"
+  else
+    printf '%s' "$default"
+  fi
+}
+
+REQUIRED_LABELS=(
+  "$(_cfg_val scope_security "$_DEFAULT_SCOPE_SECURITY")"
+  "$(_cfg_val type_tech_debt "$_DEFAULT_TYPE_TECH_DEBT")"
+  "$(_cfg_val epic           "$_DEFAULT_EPIC")"
+  "$(_cfg_val adept_to_close "$_DEFAULT_ADEPT_TO_CLOSE")"
+)
 
 if ! json_out="$(gh label list --repo "$repo" --json name --limit 500 2>/dev/null)"; then
   echo "ERROR: failed to list labels for $repo" >&2

--- a/github/security/labels.yml
+++ b/github/security/labels.yml
@@ -1,0 +1,44 @@
+# Label configuration for the security automation pipeline.
+#
+# Each key is a logical label purpose; the value is the actual GitHub label
+# name used in your repository.  Override any value to match your own
+# labelling scheme.
+#
+# Example – if your repo uses "type:epic" instead of "epic":
+#   epic: "type:epic"
+#
+# The file is optional.  When absent or when a key is missing, the built-in
+# defaults (shown below) are used.
+
+# -- Core labels applied to every security issue 
+scope_security: "scope:security"
+type_tech_debt: "type:tech-debt"
+epic: "epic"
+
+# -- Lifecycle labels 
+adept_to_close: "sec:adept-to-close"
+
+# -- Source 
+src_aquasec_sarif: "sec:src/aquasec-sarif"
+
+# -- State 
+state_postponed: "sec:state/postponed"
+state_needs_review: "sec:state/needs-review"
+
+# -- Severity
+sev_critical: "sec:sev/critical"
+sev_high: "sec:sev/high"
+sev_medium: "sec:sev/medium"
+sev_low: "sec:sev/low"
+
+# -- Closure reasons 
+close_fixed: "sec:close/fixed"
+close_false_positive: "sec:close/false-positive"
+close_accepted_risk: "sec:close/accepted-risk"
+close_not_applicable: "sec:close/not-applicable"
+
+# -- Postpone reasons
+postpone_vendor: "sec:postpone/vendor"
+postpone_platform: "sec:postpone/platform"
+postpone_roadmap: "sec:postpone/roadmap"
+postpone_other: "sec:postpone/other"

--- a/github/security/promote_alerts.py
+++ b/github/security/promote_alerts.py
@@ -57,7 +57,7 @@ from shared.github_issues import gh_issue_list_by_label
 from shared.priority import parse_severity_priority_map
 
 from utils.alert_parser import load_open_alerts_from_file
-from utils.constants import LABEL_SCOPE_SECURITY
+from utils.constants import LABEL_SCOPE_SECURITY, reload_labels
 from utils.issue_sync import sync_alerts_and_issues
 from utils.logging_config import setup_logging
 from utils.teams import notify_teams, notify_teams_severity_changes
@@ -122,6 +122,13 @@ def parse_args() -> argparse.Namespace:
         help="Teams Incoming Webhook URL for new/reopened issue alerts (default: $TEAMS_WEBHOOK_URL). "
              "If not set, Teams notification is skipped.",
     )
+    p.add_argument(
+        "--label-config",
+        default=None,
+        help="Path to a labels.yml file that maps logical label purposes to actual "
+             "GitHub label names.  When omitted, the default labels.yml next to this "
+             "script is used (and if that file is absent, built-in defaults apply).",
+    )
     return p.parse_args()
 
 
@@ -135,8 +142,27 @@ def main() -> None:
     verbose = bool(args.verbose) or parse_runner_debug()
     setup_logging(verbose)
 
+    # Load custom label configuration (must happen before any label constant
+    # is resolved elsewhere, such as in issue_sync).  Calling reload_labels()
+    # refreshes the module-level LABEL_* attributes in constants.py.
+    label_config_path: str | None = args.label_config
+    reload_labels(label_config_path)
+
+    # If the user didn't explicitly pass --issue-label, use the (possibly
+    # reconfigured) scope_security label from the config file.
+    # Argparse captured the LABEL_SCOPE_SECURITY value at import time, so to 
+    # honour a runtime --label-config you must:
+    #   1. reload the constants
+    #   2. detect whether the user actually supplied a different --issue-label (vs. the stale default)
+    #   3. if not supplied, replace the stale default with the freshly loaded label
+    from utils.constants import LABEL_SCOPE_SECURITY as _resolved  # noqa: E402
+    issue_label = str(args.issue_label)
+    
+    if issue_label == LABEL_SCOPE_SECURITY:
+        issue_label = _resolved
+
     repo_full, open_alerts = load_open_alerts_from_file(args.file)
-    issues = gh_issue_list_by_label(repo_full, str(args.issue_label))
+    issues = gh_issue_list_by_label(repo_full, issue_label)
 
     # Build severity → priority map from user input; empty by default (priority skipped).
     spm = parse_severity_priority_map(str(args.severity_priority_map or ""))

--- a/github/security/sync_security_alerts.sh
+++ b/github/security/sync_security_alerts.sh
@@ -21,6 +21,7 @@ REPO=""
 STATE="open"            # open | dismissed | fixed | all
 OUT_FILE="alerts.json"
 ISSUE_LABEL="scope:security"
+LABEL_CONFIG=""
 SEVERITY_PRIORITY_MAP="${SEVERITY_PRIORITY_MAP:-}"
 PROJECT_NUMBER="${PROJECT_NUMBER:-}"
 PROJECT_ORG="${PROJECT_ORG:-}"
@@ -47,6 +48,8 @@ Options:
   --state <state>       open | dismissed | fixed | all (default: open)
   --out <file>          Output file for alerts JSON (default: alerts.json)
   --issue-label <label> Mine existing issues with this label (default: scope:security)
+  --label-config <file>  Path to labels.yml config file that maps logical label
+                        purposes to actual label names (default: <script_dir>/labels.yml)
   --severity-priority-map <map>
                         Comma-separated severity=priority pairs, e.g.
                         'Critical=Blocker,High=Urgent,Medium=Normal,Low=Minor,Unknown=Normal'
@@ -123,6 +126,10 @@ while [[ $# -gt 0 ]]; do
       ISSUE_LABEL="$2"
       shift 2
       ;;
+    --label-config)
+      LABEL_CONFIG="$2"
+      shift 2
+      ;;
     --severity-priority-map)
       SEVERITY_PRIORITY_MAP="$2"
       shift 2
@@ -187,8 +194,12 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+CHECK_LABELS_ARGS=("$SCRIPT_DIR/check_labels.sh" --repo "$REPO")
+if [[ -n "$LABEL_CONFIG" ]]; then
+  CHECK_LABELS_ARGS+=(--label-config "$LABEL_CONFIG")
+fi
 if (( ! SKIP_LABEL_CHECK )); then
-  "$SCRIPT_DIR/check_labels.sh" --repo "$REPO"
+  "${CHECK_LABELS_ARGS[@]}"
 fi
 
 if [[ -f "$OUT_FILE" ]]; then
@@ -203,6 +214,9 @@ fi
 "$SCRIPT_DIR/collect_alert.sh" --repo "$REPO" --state "$STATE" --out "$OUT_FILE"
 
 PROMOTE_ARGS=("$SCRIPT_DIR/promote_alerts.py" --file "$OUT_FILE" --issue-label "$ISSUE_LABEL")
+if [[ -n "$LABEL_CONFIG" ]]; then
+  PROMOTE_ARGS+=(--label-config "$LABEL_CONFIG")
+fi
 if (( DRY_RUN )); then
   PROMOTE_ARGS+=(--dry-run)
 fi

--- a/github/security/tests/utils/test_constants.py
+++ b/github/security/tests/utils/test_constants.py
@@ -14,31 +14,161 @@
 # limitations under the License.
 #
 
-"""Unit tests for ``utils.constants``."""
+"""Unit tests for ``utils.constants``.
 
+These tests verify that the default label values (when no custom
+``labels.yml`` is present) match the historically hardcoded values.
+"""
+
+import textwrap
+
+import pytest
+
+from utils.label_config import reset_label_config
 from utils.constants import (
     LABEL_EPIC,
     LABEL_SCOPE_SECURITY,
     LABEL_SEC_ADEPT_TO_CLOSE,
     LABEL_TYPE_TECH_DEBT,
+    LABEL_SRC_AQUASEC_SARIF,
+    LABEL_STATE_POSTPONED,
+    LABEL_STATE_NEEDS_REVIEW,
+    LABEL_SEV_CRITICAL,
+    LABEL_SEV_HIGH,
+    LABEL_SEV_MEDIUM,
+    LABEL_SEV_LOW,
+    LABEL_CLOSE_FIXED,
+    LABEL_CLOSE_FALSE_POSITIVE,
+    LABEL_CLOSE_ACCEPTED_RISK,
+    LABEL_CLOSE_NOT_APPLICABLE,
+    LABEL_POSTPONE_VENDOR,
+    LABEL_POSTPONE_PLATFORM,
+    LABEL_POSTPONE_ROADMAP,
+    LABEL_POSTPONE_OTHER,
+    NOT_AVAILABLE,
     SEC_EVENT_OPEN,
     SEC_EVENT_REOPEN,
     SECMETA_TYPE_CHILD,
     SECMETA_TYPE_PARENT,
+    reload_labels,
 )
 
 
+def _reset() -> None:
+    """Ensure we test with built-in defaults (no custom labels.yml)."""
+    reset_label_config()
+    reload_labels()
+
+
 def test_scope_security() -> None:
+    _reset()
+    from utils.constants import LABEL_SCOPE_SECURITY
     assert LABEL_SCOPE_SECURITY == "scope:security"
 
 def test_type_tech_debt() -> None:
+    _reset()
+    from utils.constants import LABEL_TYPE_TECH_DEBT
     assert LABEL_TYPE_TECH_DEBT == "type:tech-debt"
 
 def test_epic() -> None:
+    _reset()
+    from utils.constants import LABEL_EPIC
     assert LABEL_EPIC == "epic"
 
 def test_adept_to_close() -> None:
+    _reset()
+    from utils.constants import LABEL_SEC_ADEPT_TO_CLOSE
     assert LABEL_SEC_ADEPT_TO_CLOSE == "sec:adept-to-close"
+
+
+def test_src_aquasec_sarif() -> None:
+    _reset()
+    from utils.constants import LABEL_SRC_AQUASEC_SARIF
+    assert LABEL_SRC_AQUASEC_SARIF == "sec:src/aquasec-sarif"
+
+
+def test_state_postponed() -> None:
+    _reset()
+    from utils.constants import LABEL_STATE_POSTPONED
+    assert LABEL_STATE_POSTPONED == "sec:state/postponed"
+
+
+def test_state_needs_review() -> None:
+    _reset()
+    from utils.constants import LABEL_STATE_NEEDS_REVIEW
+    assert LABEL_STATE_NEEDS_REVIEW == "sec:state/needs-review"
+
+
+def test_sev_critical() -> None:
+    _reset()
+    from utils.constants import LABEL_SEV_CRITICAL
+    assert LABEL_SEV_CRITICAL == "sec:sev/critical"
+
+
+def test_sev_high() -> None:
+    _reset()
+    from utils.constants import LABEL_SEV_HIGH
+    assert LABEL_SEV_HIGH == "sec:sev/high"
+
+
+def test_sev_medium() -> None:
+    _reset()
+    from utils.constants import LABEL_SEV_MEDIUM
+    assert LABEL_SEV_MEDIUM == "sec:sev/medium"
+
+
+def test_sev_low() -> None:
+    _reset()
+    from utils.constants import LABEL_SEV_LOW
+    assert LABEL_SEV_LOW == "sec:sev/low"
+
+
+def test_close_fixed() -> None:
+    _reset()
+    from utils.constants import LABEL_CLOSE_FIXED
+    assert LABEL_CLOSE_FIXED == "sec:close/fixed"
+
+
+def test_close_false_positive() -> None:
+    _reset()
+    from utils.constants import LABEL_CLOSE_FALSE_POSITIVE
+    assert LABEL_CLOSE_FALSE_POSITIVE == "sec:close/false-positive"
+
+
+def test_close_accepted_risk() -> None:
+    _reset()
+    from utils.constants import LABEL_CLOSE_ACCEPTED_RISK
+    assert LABEL_CLOSE_ACCEPTED_RISK == "sec:close/accepted-risk"
+
+
+def test_close_not_applicable() -> None:
+    _reset()
+    from utils.constants import LABEL_CLOSE_NOT_APPLICABLE
+    assert LABEL_CLOSE_NOT_APPLICABLE == "sec:close/not-applicable"
+
+
+def test_postpone_vendor() -> None:
+    _reset()
+    from utils.constants import LABEL_POSTPONE_VENDOR
+    assert LABEL_POSTPONE_VENDOR == "sec:postpone/vendor"
+
+
+def test_postpone_platform() -> None:
+    _reset()
+    from utils.constants import LABEL_POSTPONE_PLATFORM
+    assert LABEL_POSTPONE_PLATFORM == "sec:postpone/platform"
+
+
+def test_postpone_roadmap() -> None:
+    _reset()
+    from utils.constants import LABEL_POSTPONE_ROADMAP
+    assert LABEL_POSTPONE_ROADMAP == "sec:postpone/roadmap"
+
+
+def test_postpone_other() -> None:
+    _reset()
+    from utils.constants import LABEL_POSTPONE_OTHER
+    assert LABEL_POSTPONE_OTHER == "sec:postpone/other"
 
 
 def test_open() -> None:
@@ -53,3 +183,26 @@ def test_parent() -> None:
 
 def test_child() -> None:
     assert SECMETA_TYPE_CHILD == "child"
+
+
+def test_not_available() -> None:
+    assert NOT_AVAILABLE == "N/A"
+
+
+def test_reload_labels_with_custom_path(tmp_path) -> None:
+    """reload_labels() picks up a custom labels.yml and updates LABEL_* globals."""
+    f = tmp_path / "labels.yml"
+    f.write_text(textwrap.dedent("""\
+        epic: "type:epic"
+        sev_critical: "sev:critical"
+    """))
+    reload_labels(str(f))
+
+    import utils.constants as c
+    assert c.LABEL_EPIC == "type:epic"
+    assert c.LABEL_SEV_CRITICAL == "sev:critical"
+    # Unchanged labels still use defaults
+    assert c.LABEL_SCOPE_SECURITY == "scope:security"
+
+    # Restore defaults so we don't pollute other tests
+    _reset()

--- a/github/security/tests/utils/test_issue_sync.py
+++ b/github/security/tests/utils/test_issue_sync.py
@@ -24,6 +24,7 @@ import pytest
 from pytest_mock import MockerFixture
 
 from shared.models import Issue
+from utils.constants import LABEL_SEC_ADEPT_TO_CLOSE
 from utils.issue_sync import (
     _append_notification,
     _comment_child_event,
@@ -774,7 +775,7 @@ def test_label_orphan_found(mocker: MockerFixture) -> None:
     _label_orphan_issues(alerts, index, dry_run=False)
     mock_labels.assert_called_once()
     label_args = mock_labels.call_args[0][2]
-    assert "sec:adept-to-close" in label_args
+    assert LABEL_SEC_ADEPT_TO_CLOSE in label_args
 
 def test_label_orphan_dry_run() -> None:
     """Dry-run: logs but does not call gh."""
@@ -789,7 +790,7 @@ def test_label_orphan_skips_already_labelled() -> None:
     child = _issue_with_secmeta(1, {
         "type": "child", "fingerprint": "fp_orphan", "repo": "org/repo",
     })
-    child.labels = ["sec:adept-to-close"]
+    child.labels = [LABEL_SEC_ADEPT_TO_CLOSE]
     index = build_issue_index({1: child})
     _label_orphan_issues({}, index, dry_run=False)
 

--- a/github/security/tests/utils/test_label_config.py
+++ b/github/security/tests/utils/test_label_config.py
@@ -1,0 +1,279 @@
+#
+# Copyright 2026 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for ``utils.label_config``."""
+
+import os
+import textwrap
+
+import pytest
+
+from utils.label_config import (
+    LabelConfig,
+    _parse_yaml_flat,
+    load_label_config,
+    get_label_config,
+    reset_label_config,
+)
+
+
+# ========================dd=============================================
+# _parse_yaml_flat
+# =====================================================================
+
+
+def test_parse_empty_string() -> None:
+    assert _parse_yaml_flat("") == {}
+
+
+def test_parse_comments_and_blanks() -> None:
+    text = textwrap.dedent("""\
+        # Full-line comment
+        
+        # Another comment
+    """)
+    assert _parse_yaml_flat(text) == {}
+
+
+def test_parse_bare_values() -> None:
+    text = textwrap.dedent("""\
+        scope_security: scope:security
+        epic: type:epic
+    """)
+    result = _parse_yaml_flat(text)
+    assert result == {"scope_security": "scope:security", "epic": "type:epic"}
+
+
+def test_parse_double_quoted_values() -> None:
+    text = 'epic: "type:epic"\n'
+    assert _parse_yaml_flat(text) == {"epic": "type:epic"}
+
+
+def test_parse_single_quoted_values() -> None:
+    text = "epic: 'type:epic'\n"
+    assert _parse_yaml_flat(text) == {"epic": "type:epic"}
+
+
+def test_parse_trailing_comment() -> None:
+    text = 'epic: type:epic  # this is the epic label\n'
+    assert _parse_yaml_flat(text) == {"epic": "type:epic"}
+
+
+def test_parse_trailing_comment_quoted() -> None:
+    text = 'epic: "type:epic"  # comment\n'
+    assert _parse_yaml_flat(text) == {"epic": "type:epic"}
+
+
+def test_parse_full_config() -> None:
+    text = textwrap.dedent("""\
+        # Label config
+        scope_security: "scope:security"
+        type_tech_debt: "type:tech-debt"
+        epic: "type:epic"
+        adept_to_close: "sec:adept-to-close"
+    """)
+    result = _parse_yaml_flat(text)
+    assert result == {
+        "scope_security": "scope:security",
+        "type_tech_debt": "type:tech-debt",
+        "epic": "type:epic",
+        "adept_to_close": "sec:adept-to-close",
+    }
+
+
+# =====================================================================
+# LabelConfig
+# =====================================================================
+
+
+def test_label_config_defaults() -> None:
+    cfg = LabelConfig()
+    # Core
+    assert cfg.scope_security == "scope:security"
+    assert cfg.type_tech_debt == "type:tech-debt"
+    assert cfg.epic == "epic"
+    assert cfg.adept_to_close == "sec:adept-to-close"
+    # Source
+    assert cfg.src_aquasec_sarif == "sec:src/aquasec-sarif"
+    # State
+    assert cfg.state_postponed == "sec:state/postponed"
+    assert cfg.state_needs_review == "sec:state/needs-review"
+    # Severity
+    assert cfg.sev_critical == "sec:sev/critical"
+    assert cfg.sev_high == "sec:sev/high"
+    assert cfg.sev_medium == "sec:sev/medium"
+    assert cfg.sev_low == "sec:sev/low"
+    # Closure reasons
+    assert cfg.close_fixed == "sec:close/fixed"
+    assert cfg.close_false_positive == "sec:close/false-positive"
+    assert cfg.close_accepted_risk == "sec:close/accepted-risk"
+    assert cfg.close_not_applicable == "sec:close/not-applicable"
+    # Postpone reasons
+    assert cfg.postpone_vendor == "sec:postpone/vendor"
+    assert cfg.postpone_platform == "sec:postpone/platform"
+    assert cfg.postpone_roadmap == "sec:postpone/roadmap"
+    assert cfg.postpone_other == "sec:postpone/other"
+
+
+def test_label_config_custom() -> None:
+    cfg = LabelConfig(epic="type:epic")
+    assert cfg.epic == "type:epic"
+    # Others stay default
+    assert cfg.scope_security == "scope:security"
+
+
+def test_required_labels() -> None:
+    cfg = LabelConfig(epic="type:epic")
+    assert cfg.required_labels == [
+        "scope:security",
+        "type:tech-debt",
+        "type:epic",
+        "sec:adept-to-close",
+    ]
+
+
+def test_label_config_frozen() -> None:
+    cfg = LabelConfig()
+    with pytest.raises(AttributeError):
+        cfg.epic = "new"  # type: ignore[misc]
+
+
+def test_severity_labels() -> None:
+    cfg = LabelConfig()
+    assert cfg.severity_labels == [
+        "sec:sev/critical",
+        "sec:sev/high",
+        "sec:sev/medium",
+        "sec:sev/low",
+    ]
+
+
+def test_all_labels_count() -> None:
+    cfg = LabelConfig()
+    assert len(cfg.all_labels) == 19
+
+
+def test_all_labels_content() -> None:
+    cfg = LabelConfig()
+    assert cfg.all_labels == [
+        "scope:security",
+        "type:tech-debt",
+        "epic",
+        "sec:adept-to-close",
+        "sec:src/aquasec-sarif",
+        "sec:state/postponed",
+        "sec:state/needs-review",
+        "sec:sev/critical",
+        "sec:sev/high",
+        "sec:sev/medium",
+        "sec:sev/low",
+        "sec:close/fixed",
+        "sec:close/false-positive",
+        "sec:close/accepted-risk",
+        "sec:close/not-applicable",
+        "sec:postpone/vendor",
+        "sec:postpone/platform",
+        "sec:postpone/roadmap",
+        "sec:postpone/other",
+    ]
+
+
+def test_all_labels_no_duplicates() -> None:
+    cfg = LabelConfig()
+    assert len(cfg.all_labels) == len(set(cfg.all_labels))
+
+
+def test_all_labels_reflects_custom_values() -> None:
+    cfg = LabelConfig(epic="type:epic", sev_critical="sev:critical")
+    assert "type:epic" in cfg.all_labels
+    assert "sev:critical" in cfg.all_labels
+    assert "epic" not in cfg.all_labels
+    assert "sec:sev/critical" not in cfg.all_labels
+
+
+def test_severity_labels_custom() -> None:
+    cfg = LabelConfig(sev_high="priority:high", sev_low="priority:low")
+    assert cfg.severity_labels == [
+        "sec:sev/critical",
+        "priority:high",
+        "sec:sev/medium",
+        "priority:low",
+    ]
+
+
+# =====================================================================
+# load_label_config
+# =====================================================================
+
+
+def test_load_missing_file(tmp_path) -> None:
+    """Returns defaults when the config file doesn't exist."""
+    cfg = load_label_config(str(tmp_path / "nonexistent.yml"))
+    assert cfg == LabelConfig()
+
+
+def test_load_from_file(tmp_path) -> None:
+    f = tmp_path / "labels.yml"
+    f.write_text('epic: "type:epic"\nadept_to_close: "close-me"\n')
+    cfg = load_label_config(str(f))
+    assert cfg.epic == "type:epic"
+    assert cfg.adept_to_close == "close-me"
+    assert cfg.scope_security == "scope:security"  # default
+
+
+def test_load_unknown_keys_ignored(tmp_path) -> None:
+    f = tmp_path / "labels.yml"
+    f.write_text('epic: "type:epic"\nbogus_key: "whatever"\n')
+    cfg = load_label_config(str(f))
+    assert cfg.epic == "type:epic"
+
+
+# =====================================================================
+# get_label_config / reset_label_config (singleton)
+# =====================================================================
+
+
+def test_singleton_caching(tmp_path) -> None:
+    reset_label_config()
+    f = tmp_path / "labels.yml"
+    f.write_text('epic: "cached-value"\n')
+    cfg1 = get_label_config(str(f))
+    assert cfg1.epic == "cached-value"
+
+    # Second call without path returns cached
+    cfg2 = get_label_config()
+    assert cfg2 is cfg1
+
+    # Call with a different path reloads
+    f2 = tmp_path / "labels2.yml"
+    f2.write_text('epic: "other"\n')
+    cfg3 = get_label_config(str(f2))
+    assert cfg3.epic == "other"
+    assert cfg3 is not cfg1
+
+
+def test_reset_clears_singleton(tmp_path) -> None:
+    reset_label_config()
+    f = tmp_path / "labels.yml"
+    f.write_text('epic: "first"\n')
+    cfg1 = get_label_config(str(f))
+    assert cfg1.epic == "first"
+
+    reset_label_config()
+    # After reset, calling without path falls back to default location
+    # (which won't exist in tmp_path context), defaults.
+    cfg2 = get_label_config(str(tmp_path / "nonexistent.yml"))
+    assert cfg2.epic == "epic"  # built-in default

--- a/github/security/utils/constants.py
+++ b/github/security/utils/constants.py
@@ -14,13 +14,77 @@
 # limitations under the License.
 #
 
-"""Shared constants used across the security workflow utilities."""
+"""Shared constants used across the security workflow utilities.
 
-LABEL_SCOPE_SECURITY = "scope:security"
-LABEL_TYPE_TECH_DEBT = "type:tech-debt"
-LABEL_EPIC = "epic"
-LABEL_SEC_ADEPT_TO_CLOSE = "sec:adept-to-close"
+Label values are configurable via ``labels.yml`` (see
+:mod:`utils.label_config`).  The module-level ``LABEL_*`` attributes
+expose the *resolved* values so that existing call-sites continue to
+work without changes.
+"""
 
+# Configurable labels – populated by _load() at the bottom of this module.
+LABEL_SCOPE_SECURITY: str
+LABEL_TYPE_TECH_DEBT: str
+LABEL_EPIC: str
+LABEL_SEC_ADEPT_TO_CLOSE: str
+LABEL_SRC_AQUASEC_SARIF: str
+LABEL_STATE_POSTPONED: str
+LABEL_STATE_NEEDS_REVIEW: str
+LABEL_SEV_CRITICAL: str
+LABEL_SEV_HIGH: str
+LABEL_SEV_MEDIUM: str
+LABEL_SEV_LOW: str
+LABEL_CLOSE_FIXED: str
+LABEL_CLOSE_FALSE_POSITIVE: str
+LABEL_CLOSE_ACCEPTED_RISK: str
+LABEL_CLOSE_NOT_APPLICABLE: str
+LABEL_POSTPONE_VENDOR: str
+LABEL_POSTPONE_PLATFORM: str
+LABEL_POSTPONE_ROADMAP: str
+LABEL_POSTPONE_OTHER: str
+
+
+def _load(config_path: str | None = None) -> None:
+    """Populate module-level LABEL_* constants from the label config."""
+    from .label_config import get_label_config, reset_label_config  # lazy import
+    global LABEL_SCOPE_SECURITY, LABEL_TYPE_TECH_DEBT, LABEL_EPIC
+    global LABEL_SEC_ADEPT_TO_CLOSE, LABEL_SRC_AQUASEC_SARIF
+    global LABEL_STATE_POSTPONED, LABEL_STATE_NEEDS_REVIEW
+    global LABEL_SEV_CRITICAL, LABEL_SEV_HIGH, LABEL_SEV_MEDIUM, LABEL_SEV_LOW
+    global LABEL_CLOSE_FIXED, LABEL_CLOSE_FALSE_POSITIVE, LABEL_CLOSE_ACCEPTED_RISK, LABEL_CLOSE_NOT_APPLICABLE
+    global LABEL_POSTPONE_VENDOR, LABEL_POSTPONE_PLATFORM, LABEL_POSTPONE_ROADMAP, LABEL_POSTPONE_OTHER
+    if config_path is not None:
+        reset_label_config()
+    cfg = get_label_config(config_path)
+    LABEL_SCOPE_SECURITY       = cfg.scope_security
+    LABEL_TYPE_TECH_DEBT       = cfg.type_tech_debt
+    LABEL_EPIC                 = cfg.epic
+    LABEL_SEC_ADEPT_TO_CLOSE   = cfg.adept_to_close
+    LABEL_SRC_AQUASEC_SARIF    = cfg.src_aquasec_sarif
+    LABEL_STATE_POSTPONED      = cfg.state_postponed
+    LABEL_STATE_NEEDS_REVIEW   = cfg.state_needs_review
+    LABEL_SEV_CRITICAL         = cfg.sev_critical
+    LABEL_SEV_HIGH             = cfg.sev_high
+    LABEL_SEV_MEDIUM           = cfg.sev_medium
+    LABEL_SEV_LOW              = cfg.sev_low
+    LABEL_CLOSE_FIXED          = cfg.close_fixed
+    LABEL_CLOSE_FALSE_POSITIVE = cfg.close_false_positive
+    LABEL_CLOSE_ACCEPTED_RISK  = cfg.close_accepted_risk
+    LABEL_CLOSE_NOT_APPLICABLE = cfg.close_not_applicable
+    LABEL_POSTPONE_VENDOR      = cfg.postpone_vendor
+    LABEL_POSTPONE_PLATFORM    = cfg.postpone_platform
+    LABEL_POSTPONE_ROADMAP     = cfg.postpone_roadmap
+    LABEL_POSTPONE_OTHER       = cfg.postpone_other
+
+
+def reload_labels(config_path: str | None = None) -> None:
+    _load(config_path)
+
+
+# Initialise LABEL_* at module load time 
+_load()
+
+# Non-label constants
 SEC_EVENT_OPEN = "open"
 SEC_EVENT_REOPEN = "reopen"
 

--- a/github/security/utils/label_config.py
+++ b/github/security/utils/label_config.py
@@ -1,0 +1,252 @@
+#
+# Copyright 2026 ABSA Group Limited
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Load label configuration from a YAML file.
+
+The config file (``labels.yml``) is a flat key→value mapping that lets
+each consuming repository customise the GitHub label names used by the
+security automation pipeline.
+
+When the file is absent, or when a key is not present, the built-in
+defaults are used.
+
+The YAML dialect supported here is intentionally minimal (flat scalars
+only) so that we avoid an external PyYAML dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+_DEFAULTS: dict[str, str] = {
+    # Core
+    "scope_security": "scope:security",
+    "type_tech_debt": "type:tech-debt",
+    "epic": "epic",
+    # Lifecycle
+    "adept_to_close": "sec:adept-to-close",
+    # Source
+    "src_aquasec_sarif": "sec:src/aquasec-sarif",
+    # State
+    "state_postponed": "sec:state/postponed",
+    "state_needs_review": "sec:state/needs-review",
+    # Severity
+    "sev_critical": "sec:sev/critical",
+    "sev_high": "sec:sev/high",
+    "sev_medium": "sec:sev/medium",
+    "sev_low": "sec:sev/low",
+    # Closure reasons
+    "close_fixed": "sec:close/fixed",
+    "close_false_positive": "sec:close/false-positive",
+    "close_accepted_risk": "sec:close/accepted-risk",
+    "close_not_applicable": "sec:close/not-applicable",
+    # Postpone reasons
+    "postpone_vendor": "sec:postpone/vendor",
+    "postpone_platform": "sec:postpone/platform",
+    "postpone_roadmap": "sec:postpone/roadmap",
+    "postpone_other": "sec:postpone/other",
+}
+
+# Valid keys - anything outside this set is rejected early.
+_VALID_KEYS = frozenset(_DEFAULTS.keys())
+
+# Simple YAML scalar parser: ``key: value`` or ``key: "value"`` or ``key: 'value'``
+_LINE_RE = re.compile(
+    r"^(?P<key>[a-z_]+)"        # key: lowercase + underscores
+    r"\s*:\s*"                   # colon separator
+    r"(?:"
+    r"\"(?P<dq>[^\"]*)\""       # double-quoted value
+    r"|'(?P<sq>[^']*)'"         # single-quoted value
+    r"|(?P<bare>\S[^\n#]*?)"    # bare (unquoted) value
+    r")\s*(?:#.*)?"             # optional trailing comment
+    r"$"
+)
+
+
+def _parse_yaml_flat(text: str) -> dict[str, str]:
+    """Parse a flat YAML file into a ``{key: value}`` dict.
+
+    Only ``key: value``, ``key: "value"``, and ``key: 'value'`` lines
+    are recognised.  Comments (``#``) and blank lines are skipped.
+    """
+    result: dict[str, str] = {}
+    for lineno, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        m = _LINE_RE.match(line)
+        if not m:
+            logging.warning("labels.yml:%d: ignoring unparseable line: %s", lineno, raw_line)
+            continue
+        key = m.group("key")
+        value = m.group("dq") if m.group("dq") is not None else (
+            m.group("sq") if m.group("sq") is not None else (m.group("bare") or "").strip()
+        )
+        result[key] = value
+    return result
+
+
+@dataclass(frozen=True)
+class LabelConfig:
+    """Resolved label names for the security automation pipeline."""
+
+    # Core
+    scope_security: str = _DEFAULTS["scope_security"]
+    type_tech_debt: str = _DEFAULTS["type_tech_debt"]
+    epic: str = _DEFAULTS["epic"]
+
+    # Lifecycle
+    adept_to_close: str = _DEFAULTS["adept_to_close"]
+
+    # Source
+    src_aquasec_sarif: str = _DEFAULTS["src_aquasec_sarif"]
+
+    # State
+    state_postponed: str = _DEFAULTS["state_postponed"]
+    state_needs_review: str = _DEFAULTS["state_needs_review"]
+
+    # Severity
+    sev_critical: str = _DEFAULTS["sev_critical"]
+    sev_high: str = _DEFAULTS["sev_high"]
+    sev_medium: str = _DEFAULTS["sev_medium"]
+    sev_low: str = _DEFAULTS["sev_low"]
+
+    # Closure reasons
+    close_fixed: str = _DEFAULTS["close_fixed"]
+    close_false_positive: str = _DEFAULTS["close_false_positive"]
+    close_accepted_risk: str = _DEFAULTS["close_accepted_risk"]
+    close_not_applicable: str = _DEFAULTS["close_not_applicable"]
+
+    # Postpone reasons
+    postpone_vendor: str = _DEFAULTS["postpone_vendor"]
+    postpone_platform: str = _DEFAULTS["postpone_platform"]
+    postpone_roadmap: str = _DEFAULTS["postpone_roadmap"]
+    postpone_other: str = _DEFAULTS["postpone_other"]
+
+    @property
+    def required_labels(self) -> list[str]:
+        """Labels that must exist in the target repository.
+
+        Only the four core/lifecycle labels are required.  The remaining
+        labels are part of the naming convention but may not be created
+        upfront in every repository.
+        """
+        return [
+            self.scope_security,
+            self.type_tech_debt,
+            self.epic,
+            self.adept_to_close,
+        ]
+
+    @property
+    def all_labels(self) -> list[str]:
+        """Every label defined in the config (all categories)."""
+        return [
+            self.scope_security,
+            self.type_tech_debt,
+            self.epic,
+            self.adept_to_close,
+            self.src_aquasec_sarif,
+            self.state_postponed,
+            self.state_needs_review,
+            self.sev_critical,
+            self.sev_high,
+            self.sev_medium,
+            self.sev_low,
+            self.close_fixed,
+            self.close_false_positive,
+            self.close_accepted_risk,
+            self.close_not_applicable,
+            self.postpone_vendor,
+            self.postpone_platform,
+            self.postpone_roadmap,
+            self.postpone_other,
+        ]
+
+    @property
+    def severity_labels(self) -> list[str]:
+        """Severity labels, ordered critical → low."""
+        return [self.sev_critical, self.sev_high, self.sev_medium, self.sev_low]
+
+
+# Module-level singleton – lazily initialised.
+_config: LabelConfig | None = None
+
+
+def load_label_config(path: str | None = None) -> LabelConfig:
+    """Load and return a :class:`LabelConfig` from *path*.
+
+    Parameters
+    ----------
+    path:
+        Filesystem path to a ``labels.yml`` file.  When *None*, the
+        function looks for ``labels.yml`` next to *this* module's
+        package (i.e. ``github/security/labels.yml``).
+
+    Returns
+    -------
+    LabelConfig
+        A frozen dataclass with the resolved label values.
+    """
+    if path is None:
+        # Default: <security_dir>/labels.yml
+        security_dir = os.path.normpath(os.path.join(os.path.dirname(__file__), ".."))
+        path = os.path.join(security_dir, "labels.yml")
+
+    if not os.path.isfile(path):
+        logging.debug("Label config file not found at %s – using built-in defaults", path)
+        return LabelConfig()
+
+    logging.debug("Loading label config from %s", path)
+    with open(path, encoding="utf-8") as fh:
+        raw = _parse_yaml_flat(fh.read())
+
+    unknown = set(raw.keys()) - _VALID_KEYS
+    if unknown:
+        logging.warning("labels.yml: ignoring unknown keys: %s", ", ".join(sorted(unknown)))
+
+    kwargs: dict[str, Any] = {}
+    for key in _VALID_KEYS:
+        if key in raw:
+            kwargs[key] = raw[key]
+
+    return LabelConfig(**kwargs)
+
+
+def get_label_config(path: str | None = None) -> LabelConfig:
+    """Return the module-level :class:`LabelConfig` singleton.
+
+    The config is loaded on first call and cached afterwards.
+    Pass *path* to override the default file location (useful in tests
+    or when called from a CLI that accepts ``--label-config``).
+
+    Calling with a non-None *path* **always** reloads from disk
+    (and replaces the cached singleton).
+    """
+    global _config
+    if _config is None or path is not None:
+        _config = load_label_config(path)
+    return _config
+
+
+def reset_label_config() -> None:
+    """Clear the cached singleton (for tests)."""
+    global _config
+    _config = None

--- a/github/security/workflows/aquasec-night-scan.yml
+++ b/github/security/workflows/aquasec-night-scan.yml
@@ -18,6 +18,21 @@
 # .github/workflows/aquasec-night-scan.yml
 #
 # It delegates to the reusable workflow in the organizational-workflows repo.
+#
+# Label customisation
+# -------------------
+# By default the workflow uses the built-in label names (scope:security, epic,
+# sec:adept-to-close, etc.).  To override any of them, add a file at
+#
+#   .github/labels.yml
+#
+# in THIS (caller) repository with only the keys that differ, e.g.:
+#
+#   scope_security: "type:security"
+#   epic:           "type:epic"
+#
+# The full list of configurable keys is documented in:
+#   https://github.com/AbsaOSS/organizational-workflows/blob/master/github/security/labels.yml
 
 name: Aquasec Night Scan
 


### PR DESCRIPTION
Closes #8 

Release Note:
- make all workflow labels configurable via `labels.yml` and a `--label-config` flag
- lazy-load label config in utils/constants and add reload_labels() to apply changes at runtime