### PR TITLE
feat: Removing adept to close label logic

### DIFF
--- a/.github/workflows/aquasec-night-scan.yml
+++ b/.github/workflows/aquasec-night-scan.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   aquasec-night-scan:
-    uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@d3e4ff77b60db1bcd5b485ccedf19d2216d39621
+    uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@feature/82-remove-adept-to-close-label-need
     with:
       dry-run: ${{ inputs.dry-run || false }}
       min-severity: 'medium'

--- a/.github/workflows/aquasec-night-scan.yml
+++ b/.github/workflows/aquasec-night-scan.yml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   aquasec-night-scan:
-    uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@feature/82-remove-adept-to-close-label-need
+    uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@d3e4ff77b60db1bcd5b485ccedf19d2216d39621
     with:
       dry-run: ${{ inputs.dry-run || false }}
       min-severity: 'medium'

--- a/.github/workflows/aquasec-night-scan.yml
+++ b/.github/workflows/aquasec-night-scan.yml
@@ -41,7 +41,7 @@ jobs:
     uses: AbsaOSS/organizational-workflows/.github/workflows/aquasec-scan.yml@d3e4ff77b60db1bcd5b485ccedf19d2216d39621
     with:
       dry-run: ${{ inputs.dry-run || false }}
-      min-severity: 'medium'
+      min-severity: 'high'
       project-number: 203
       project-org: 'absa-group'
     secrets:

--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: AbsaOSS/organizational-workflows
-          ref: ${{ job.workflow_sha }}
+          ref: ${{ github.job_workflow_sha }}
           path: org-workflows
           persist-credentials: false
 

--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -68,7 +68,7 @@ on:
         description: >
           Minimum severity level for issue creation. Accepted values: low, medium, high, critical
           (case-insensitive). Findings below this threshold are still fetched and still drive
-          adept-to-close lifecycle for previously created issues, but will not create or reopen
+          the closure lifecycle for previously created issues, but will not create or reopen
           issues. Defaults to 'low', which creates issues for all findings.
         required: false
         type: string

--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -100,7 +100,7 @@ jobs:
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
         with:
           repository: AbsaOSS/organizational-workflows
-          ref: ${{ github.job_workflow_sha }}
+          ref: ${{ job.workflow_sha }}
           path: org-workflows
           persist-credentials: false
 

--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -90,15 +90,15 @@ jobs:
         id: analyze-code
         run: |
           pylint_score=$(pylint $(git ls-files '*.py')| grep 'rated at' | awk '{print $7}' | cut -d'/' -f1)
-          echo "PYLINT_SCORE=$pylint_score" >> $GITHUB_ENV
+          printf 'PYLINT_SCORE=%s\n' "$pylint_score" >> "$GITHUB_ENV"
 
       - name: Check Pylint score
         run: |
           if (( $(echo "$PYLINT_SCORE < 9.0" | bc -l) )); then
-            echo "Failure: Pylint score is below 9.0 (project score: $PYLINT_SCORE)."
+            printf 'Failure: Pylint score is below 9.0 (project score: %s).\n' "$PYLINT_SCORE"
             exit 1
           else
-            echo "Success: Pylint score is above 9.0 (project score: $PYLINT_SCORE)."
+            printf 'Success: Pylint score is above 9.0 (project score: %s).\n' "$PYLINT_SCORE"
           fi
 
   black-check:

--- a/.github/workflows/check_python.yml
+++ b/.github/workflows/check_python.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Check Pylint score
         run: |
-          if (( $(echo "$PYLINT_SCORE < 9.0" | bc -l) )); then
+          if (( $(printf '%s < 9.0\n' "$PYLINT_SCORE" | bc -l) )); then
             printf 'Failure: Pylint score is below 9.0 (project score: %s).\n' "$PYLINT_SCORE"
             exit 1
           else

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -19,7 +19,7 @@ flowchart TD
     A["🔑 Authenticate with AquaSec API"]
     B["📥 Fetch and Normalise Findings"]
     C["📝 Create / Update / Reopen Issues"]
-    D["🏷️ Label Resolved Findings"]
+    D["✅ Close Resolved Findings"]
     E["📣 Send Notifications"]
 
     A --> B --> C --> D --> E
@@ -37,7 +37,7 @@ flowchart TD
 
 3. **Create / Update / Reopen Issues**: New findings become new GitHub Issues. Existing findings are updated with the latest occurrence data. Previously closed findings that reappear are automatically reopened. Parent issues (epics) group findings by rule and auto-close when all children are resolved.
 
-4. **Mark Resolved Findings**: Issues for findings that are no longer detected are labelled `sec:adept-to-close`, signalling they are ready to be closed manually.
+4. **Close Resolved Findings**: Issues for findings that are no longer detected in the scan are **automatically closed**. Closed issues remain searchable and traceable through their history and any waiver labels.
 
 5. **Send Notifications**: When new or reopened findings are detected a notification can be sent automatically.
 
@@ -47,10 +47,26 @@ flowchart TD
 
 - **Zero manual triage**: New findings from AquaSec scans automatically become Issues with severity, context, and links to the affected code.
 - **Single source of truth**: GitHub Issues is the system of record. No need to check a separate security portal.
-- **Lifecycle automation**: Issues are reopened when findings reappear, labeled for closure when resolved, and updated if needed.
+- **Lifecycle automation**: Issues are reopened when findings reappear, automatically closed when resolved, and updated if needed.
 - **Notifications**: Option to notify the team of new or reopened security findings in real-time.
 - **Priority sync**: Findings are mapped to priority levels on a ProjectV2 board, keeping planning and security aligned.
 - **Organisational scale**: Shared reusable workflows mean every repository gets the same security process with a single caller workflow.
+
+---
+
+## Waivers
+
+Sometimes a finding should be accepted rather than fixed. Either because it is a
+**suppression** or a **false positive**. These waivers are handled by people,
+not the pipeline. Pipeline never adds, removes, or reads these labels.
+
+To record a waiver, apply the matching label to the child issue and add a comment
+linking the related Jira ticket:
+
+| Label | Meaning |
+| --- | --- |
+| `sec:suppression` | A real finding is knowingly accepted for a period. |
+| `sec:false-positive` | A finding is confirmed not to be a real issue. |
 
 ---
 

--- a/src/core/github/issues.py
+++ b/src/core/github/issues.py
@@ -278,21 +278,6 @@ def gh_issue_add_labels(repo: str, number: int, labels: list[str]) -> None:
         logging.warning("Failed to add labels to #%d%s: %s", number, _not_found_hint(res), res.stderr)
 
 
-def gh_issue_remove_labels(repo: str, number: int, labels: list[str]) -> None:
-    """Remove *labels* from issue *number* (idempotent)."""
-    if not labels:
-        return
-
-    args: list[str] = ["issue", "edit", str(number), "--repo", repo]
-
-    for label in labels:
-        args += ["--remove-label", label]
-
-    res = run_gh(args)
-    if res.returncode != 0:
-        logging.warning("Failed to remove labels from #%d%s: %s", number, _not_found_hint(res), res.stderr)
-
-
 def gh_issue_comment(repo: str, number: int, body: str) -> bool:
     """Post a comment with *body* on issue *number*.
 

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -38,7 +38,8 @@ To use this solution, make sure your environment meets the following requirement
 - AquaSec API credentials (Key and Secret)
 - AquaSec Group ID for authentication
 - AquaSec Repository ID (UUID format) for the target scan results
-- Required labels in the target repository: `scope:security`, `type:tech-debt`, `sec:adept-to-close`, `epic`
+- Required labels in the target repository: `scope:security`, `type:tech-debt`, `epic`
+- Standard labels for manual waiver tracking: `sec:suppression`, `sec:false-positive`
 
 ---
 
@@ -139,7 +140,7 @@ The entry point is `src/security/main.py`. It runs the full pipeline: authentica
 
 - Python 3.14 (current required runtime)
 - Install and authenticate GitHub CLI: `gh auth login`
-- Required labels must exist in the target repository: `scope:security`, `type:tech-debt`, `sec:adept-to-close`, `epic`
+- Required labels must exist in the target repository: `scope:security`, `type:tech-debt`, `epic`
 - AquaSec credentials available as environment variables: `AQUA_KEY`, `AQUA_SECRET`, `AQUA_GROUP_ID`, `AQUA_REPOSITORY_ID`
 
 ### Commands

--- a/src/security/README.md
+++ b/src/security/README.md
@@ -22,7 +22,7 @@ Solution supports:
 
 - **Automated Issue creation**: Each unique finding becomes a GitHub Issue with severity, affected file, and remediation context.
 - **Parent/child structure**: Findings are grouped under epic (parent) issues by rule, with individual occurrences as child sub-issues.
-- **Lifecycle sync**: Issues are reopened when findings reappear, marked as ready-to-close when findings disappear, and parent issues auto-close when all children are resolved.
+- **Lifecycle sync**: Issues are reopened when findings reappear, automatically closed when findings disappear, and parent issues auto-close when all children are resolved.
 - **Teams notifications**: New and reopened findings trigger a Microsoft Teams Adaptive Card notification.
 - **Priority sync**: Severity is mapped to priority on a GitHub ProjectV2 board.
 

--- a/src/security/constants.py
+++ b/src/security/constants.py
@@ -19,13 +19,11 @@
 LABEL_SCOPE_SECURITY = "scope:security"
 LABEL_TYPE_TECH_DEBT = "type:tech-debt"
 LABEL_EPIC = "epic"
-LABEL_SEC_ADEPT_TO_CLOSE = "sec:adept-to-close"
 
 REQUIRED_LABELS: list[str] = [
     LABEL_SCOPE_SECURITY,
     LABEL_TYPE_TECH_DEBT,
     LABEL_EPIC,
-    LABEL_SEC_ADEPT_TO_CLOSE,
 ]
 
 SECMETA_KEYS_PARENT = {"type", "repo", "rule_id", "severity"}

--- a/src/security/issues/models.py
+++ b/src/security/issues/models.py
@@ -93,7 +93,7 @@ class SyncStats:
     children_title_updated: int = 0
     children_body_updated: int = 0
     children_linked: int = 0
-    children_marked_for_closure: int = 0
+    children_closed: int = 0
 
 
 @dataclass

--- a/src/security/issues/sync.py
+++ b/src/security/issues/sync.py
@@ -33,7 +33,6 @@ from core.github.issues import (
     gh_issue_edit_state,
     gh_issue_edit_title,
     gh_issue_get_sub_issue_numbers,
-    gh_issue_remove_labels,
 )
 from core.github.projects import ProjectPrioritySync, gh_project_get_priority_field
 from core.models import Issue
@@ -44,7 +43,6 @@ from security.constants import (
     DRY_RUN_PREFIX,
     LABEL_EPIC,
     LABEL_SCOPE_SECURITY,
-    LABEL_SEC_ADEPT_TO_CLOSE,
     LABEL_TYPE_TECH_DEBT,
     LOGGING_PREFIX,
     SECMETA_TYPE_CHILD,
@@ -447,28 +445,6 @@ def _handle_new_child_issue(
         sync.priority_sync.enqueue(ctx.repo, num, ctx.severity, sync.severity_priority_map)
 
 
-def _remove_adept_to_close_label(repo: str, issue: Issue, *, dry_run: bool) -> None:
-    """Remove the ``sec:adept-to-close`` label from *issue* if present."""
-    if not issue.labels or LABEL_SEC_ADEPT_TO_CLOSE not in issue.labels:
-        return
-
-    if dry_run:
-        logging.info(
-            DRY_RUN_PREFIX + "Would remove label %r from issue #%d",
-            LABEL_SEC_ADEPT_TO_CLOSE,
-            issue.number,
-        )
-    else:
-        logging.info(
-            LOGGING_PREFIX + "Removed label %r from reopened issue #%d",
-            LABEL_SEC_ADEPT_TO_CLOSE,
-            issue.number,
-        )
-        gh_issue_remove_labels(repo, issue.number, [LABEL_SEC_ADEPT_TO_CLOSE])
-
-    issue.labels.remove(LABEL_SEC_ADEPT_TO_CLOSE)
-
-
 def _maybe_reopen_child(
     *,
     ctx: AlertContext,
@@ -495,7 +471,6 @@ def _maybe_reopen_child(
 
     if reopened:
         sync.stats.children_reopened += 1
-        _remove_adept_to_close_label(ctx.repo, issue, dry_run=sync.dry_run)
         maybe_reopen_parent_issue(
             ctx.repo,
             parent_issue,
@@ -765,14 +740,14 @@ def _flush_parent_body_updates(
                     stats.parents_body_updated += 1
 
 
-def _label_adept_to_close_issues(
+def _close_resolved_child_issues(
     alerts: dict[int, Alert],
     index: IssueIndex,
     *,
     dry_run: bool,
     stats: SyncStats,
 ) -> None:
-    """Detect open child issues with no matching alert and add the adept-to-close label."""
+    """Close open child issues whose alert is no longer present in the scan results."""
     alert_fingerprints: set[str] = set()
     for alert in alerts.values():
         fp = alert.alert_details.alert_hash
@@ -783,7 +758,7 @@ def _label_adept_to_close_issues(
     unmatched_fps = open_issue_fps - alert_fingerprints
 
     if not unmatched_fps:
-        logging.debug("No unmatched child issues – skipping adept-to-close labeling")
+        logging.debug("No unmatched child issues – skipping resolved-alert closure")
         return
 
     logging.info(LOGGING_PREFIX + "Detected %d child issue/s with no matching alert", len(unmatched_fps))
@@ -792,28 +767,22 @@ def _label_adept_to_close_issues(
         issue = index.by_fingerprint[fp]
         repo = load_secmeta(issue.body).get("repo", "")
         if not repo:
-            logging.debug("Skipping adept-to-close labeling for issue #%d: no repo in secmeta", issue.number)
-            continue
-        if issue.labels and LABEL_SEC_ADEPT_TO_CLOSE in issue.labels:
-            logging.debug(
-                "Label %r already on issue #%d (fingerprint=%s…) – skipping",
-                LABEL_SEC_ADEPT_TO_CLOSE,
-                issue.number,
-                fp[:12],
-            )
+            logging.debug("Skipping closure for issue #%d: no repo in secmeta", issue.number)
             continue
         if dry_run:
             logging.info(
-                DRY_RUN_PREFIX + "Would mark issue #%d for closure (no matching alert)",
+                DRY_RUN_PREFIX + "Would close issue #%d (finding no longer detected in scan)",
                 issue.number,
             )
-        else:
+            issue.state = "closed"
+            stats.children_closed += 1
+        elif gh_issue_edit_state(repo, issue.number, "closed"):
             logging.info(
-                LOGGING_PREFIX + "Marked issue #%d for closure (no matching alert)",
+                LOGGING_PREFIX + "Closed issue #%d (finding no longer detected in scan)",
                 issue.number,
             )
-            gh_issue_add_labels(repo, issue.number, [LABEL_SEC_ADEPT_TO_CLOSE])
-        stats.children_marked_for_closure += 1
+            issue.state = "closed"
+            stats.children_closed += 1
 
 
 def _meets_min_severity(severity: str, min_severity: str) -> bool:
@@ -865,7 +834,7 @@ def sync_alerts_and_issues(
         if not _meets_min_severity(alert.metadata.severity, min_severity):
             # Below threshold: skip issue creation, update, and reopen for this alert.
             # Existing open issues for this finding are intentionally left frozen — they
-            # will only be touched by adept-to-close logic if the finding later disappears.
+            # will only be closed by resolved-alert logic if the finding later disappears.
             continue
         ensure_issue(alert, sync)
 
@@ -874,7 +843,7 @@ def sync_alerts_and_issues(
     if priority_sync is not None:
         priority_sync.flush()
 
-    _label_adept_to_close_issues(alerts, index, dry_run=dry_run, stats=sync.stats)
+    _close_resolved_child_issues(alerts, index, dry_run=dry_run, stats=sync.stats)
     _close_resolved_parent_issues(issues, index, dry_run=dry_run, stats=sync.stats)
 
     _log_sync_summary(sync.stats, dry_run=dry_run)
@@ -909,8 +878,8 @@ def _log_sync_summary(stats: SyncStats, *, dry_run: bool) -> None:
         child_parts.append(f"body updated: {stats.children_body_updated}")
     if stats.children_linked:
         child_parts.append(f"linked: {stats.children_linked}")
-    if stats.children_marked_for_closure:
-        child_parts.append(f"marked for closure: {stats.children_marked_for_closure}")
+    if stats.children_closed:
+        child_parts.append(f"closed: {stats.children_closed}")
 
     if not parent_parts and not child_parts:
         logging.info(prefix + "Sync complete: no changes")

--- a/tests/core/github/test_issues.py
+++ b/tests/core/github/test_issues.py
@@ -41,7 +41,6 @@ from core.github.issues import (
     gh_issue_get_rest_id,
     gh_issue_get_sub_issue_numbers,
     gh_issue_list_by_label,
-    gh_issue_remove_labels,
 )
 
 
@@ -330,18 +329,7 @@ def test_add_labels_not_found_hint(mocker: MockerFixture, caplog) -> None:
     assert any("deleted or transferred" in r.message for r in caplog.records)
 
 
-# gh_issue_remove_labels
-
-def test_remove_labels_success(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("core.github.issues.run_gh", return_value=_ok())
-    gh_issue_remove_labels("org/repo", 1, ["sec:adept-to-close"])
-    mock_run.assert_called_once()
-
-def test_remove_labels_no_labels_skips_call(mocker: MockerFixture) -> None:
-    mock_run = mocker.patch("core.github.issues.run_gh")
-    gh_issue_remove_labels("org/repo", 1, [])
-    mock_run.assert_not_called()
-
+# gh_issue_create
 
 def test_create_issue_success_url(mocker: MockerFixture) -> None:
     mocker.patch(

--- a/tests/security/issues/test_sync.py
+++ b/tests/security/issues/test_sync.py
@@ -27,19 +27,18 @@ from pytest_mock import MockerFixture
 from core.models import Issue
 from security.issues.sync import (
     _append_notification,
+    _close_resolved_child_issues,
     _close_resolved_parent_issues,
     _ensure_child_linked_to_parent,
     _flush_parent_body_updates,
     _handle_existing_child_issue,
     _handle_new_child_issue,
     _init_priority_sync,
-    _label_adept_to_close_issues,
     _log_sync_summary,
     _maybe_reopen_child,
     _meets_min_severity,
     _merge_child_secmeta,
     _rebuild_and_apply_child_body,
-    _remove_adept_to_close_label,
     _sync_child_title_and_labels,
     build_issue_index,
     ensure_issue,
@@ -434,43 +433,18 @@ def test_reopen_child_real_updates_state(mocker: MockerFixture) -> None:
     assert "open" == issue.state
 
 
-# _remove_adept_to_close_label
+# _maybe_reopen_child waiver labels
 
-def test_remove_adept_label_present(mocker: MockerFixture) -> None:
-    """Removes sec:adept-to-close label when present on a reopened issue."""
-    mock_remove = mocker.patch("security.issues.sync.gh_issue_remove_labels")
-    issue = Issue(number=1, state="open", title="T", body="b", labels=["scope:security", "sec:adept-to-close"])
-    _remove_adept_to_close_label("org/repo", issue, dry_run=False)
-    mock_remove.assert_called_once_with("org/repo", 1, ["sec:adept-to-close"])
-    assert "sec:adept-to-close" not in issue.labels
-
-
-def test_remove_adept_label_not_present(mocker: MockerFixture) -> None:
-    """No-op when sec:adept-to-close label is not on the issue."""
-    mock_remove = mocker.patch("security.issues.sync.gh_issue_remove_labels")
-    issue = Issue(number=1, state="open", title="T", body="b", labels=["scope:security"])
-    _remove_adept_to_close_label("org/repo", issue, dry_run=False)
-    mock_remove.assert_not_called()
-
-
-def test_remove_adept_label_none_labels() -> None:
-    """No-op when issue.labels is None."""
-    issue = Issue(number=1, state="open", title="T", body="b", labels=None)
-    _remove_adept_to_close_label("org/repo", issue, dry_run=False)
-
-
-def test_reopen_child_removes_adept_label(mocker: MockerFixture) -> None:
-    """Reopening a child issue also removes the sec:adept-to-close label."""
+def test_reopen_child_leaves_waiver_labels_untouched(mocker: MockerFixture) -> None:
+    """Reopening a child issue does not add or remove human-owned waiver labels."""
     mocker.patch("security.issues.sync.gh_issue_edit_state", return_value=True)
-    mock_remove = mocker.patch("security.issues.sync.gh_issue_remove_labels")
     body = render_secmeta({"type": "child", "category": "sast"}) + "\nbody"
-    issue = Issue(number=5, state="closed", title="T", body=body, labels=["scope:security", "sec:adept-to-close"])
+    issue = Issue(number=5, state="closed", title="T", body=body, labels=["scope:security", "sec:suppression"])
     ctx = _make_alert_context()
     sync = _make_sync_context()
     result = _maybe_reopen_child(ctx=ctx, sync=sync, issue=issue, parent_issue=None)
     assert result is True
-    mock_remove.assert_called_once_with("test-org/test-repo", 5, ["sec:adept-to-close"])
-    assert "sec:adept-to-close" not in issue.labels
+    assert "sec:suppression" in issue.labels
 
 
 # =====================================================================
@@ -902,70 +876,71 @@ def test_flush_missing_issue() -> None:
 
 
 # =====================================================================
-# _label_adept_to_close_issues
+# _close_resolved_child_issues
 # =====================================================================
 
 
-def test_label_orphan_no_orphans() -> None:
-    """No labelling when all children have matching alerts."""
+def test_close_resolved_child_no_orphans() -> None:
+    """No closure when all children have matching alerts."""
     child = _issue_with_secmeta(1, {"type": "child", "fingerprint": "fp1"})
     index = build_issue_index({1: child})
     alerts: dict[int, Alert] = {
         100: Alert.from_dict(
             {"metadata": {"state": "open"}, "alert_details": {"alert_hash": "fp1"}, "rule_details": {}}),
     }
-    _label_adept_to_close_issues(alerts, index, dry_run=False, stats=SyncStats())
+    _close_resolved_child_issues(alerts, index, dry_run=False, stats=SyncStats())
 
 
-def test_label_orphan_found(mocker: MockerFixture) -> None:
-    """Labels child issues that have no matching alert."""
-    mock_labels = mocker.patch("security.issues.sync.gh_issue_add_labels")
+def test_close_resolved_child_found(mocker: MockerFixture) -> None:
+    """Closes child issues that have no matching alert."""
+    mock_edit = mocker.patch("security.issues.sync.gh_issue_edit_state", return_value=True)
     child = _issue_with_secmeta(1, {
         "type": "child", "fingerprint": "fp_orphan", "repo": "org/repo",
     })
     index = build_issue_index({1: child})
-    alerts: dict[int, Alert] = {}
-    _label_adept_to_close_issues(alerts, index, dry_run=False, stats=SyncStats())
-    mock_labels.assert_called_once()
-    label_args = mock_labels.call_args[0][2]
-    assert "sec:adept-to-close" in label_args
+    stats = SyncStats()
+    _close_resolved_child_issues({}, index, dry_run=False, stats=stats)
+    mock_edit.assert_called_once_with("org/repo", 1, "closed")
+    assert 1 == stats.children_closed
+    assert "closed" == child.state
 
 
-def test_label_orphan_dry_run() -> None:
-    """Dry-run: logs but does not call gh."""
+def test_close_resolved_child_dry_run(mocker: MockerFixture) -> None:
+    """Dry-run: increments stat and marks state without calling gh."""
+    mock_edit = mocker.patch("security.issues.sync.gh_issue_edit_state")
     child = _issue_with_secmeta(1, {
         "type": "child", "fingerprint": "fp_orphan", "repo": "org/repo",
     })
     index = build_issue_index({1: child})
-    _label_adept_to_close_issues({}, index, dry_run=True, stats=SyncStats())
+    stats = SyncStats()
+    _close_resolved_child_issues({}, index, dry_run=True, stats=stats)
+    mock_edit.assert_not_called()
+    assert 1 == stats.children_closed
+    assert "closed" == child.state
 
 
-def test_label_orphan_skips_already_labelled() -> None:
-    """Skips if adept-to-close label is already present."""
-    child = _issue_with_secmeta(1, {
-        "type": "child", "fingerprint": "fp_orphan", "repo": "org/repo",
-    })
-    child.labels = ["sec:adept-to-close"]
-    index = build_issue_index({1: child})
-    _label_adept_to_close_issues({}, index, dry_run=False, stats=SyncStats())
-
-
-def test_label_orphan_skips_closed_issues() -> None:
-    """Closed child issues are not labelled as unmatched."""
+def test_close_resolved_child_skips_closed_issues() -> None:
+    """Closed child issues are not treated as unmatched."""
     child = _issue_with_secmeta(1, {
         "type": "child", "fingerprint": "fp_orphan", "repo": "org/repo",
     }, state="closed")
     index = build_issue_index({1: child})
-    _label_adept_to_close_issues({}, index, dry_run=False, stats=SyncStats())
+    stats = SyncStats()
+    _close_resolved_child_issues({}, index, dry_run=False, stats=stats)
+    assert 0 == stats.children_closed
 
 
-def test_label_orphan_no_repo_in_secmeta() -> None:
-    """Skips labelling if no repo in secmeta."""
+def test_close_resolved_child_no_repo_in_secmeta(mocker: MockerFixture) -> None:
+    """Skips closure if no repo in secmeta."""
+    mock_edit = mocker.patch("security.issues.sync.gh_issue_edit_state")
     child = _issue_with_secmeta(1, {
         "type": "child", "fingerprint": "fp_orphan",
     })
     index = build_issue_index({1: child})
-    _label_adept_to_close_issues({}, index, dry_run=False, stats=SyncStats())
+    stats = SyncStats()
+    _close_resolved_child_issues({}, index, dry_run=False, stats=stats)
+    mock_edit.assert_not_called()
+    assert 0 == stats.children_closed
 
 
 # =====================================================================
@@ -1100,6 +1075,29 @@ def test_sync_closes_parent_when_all_children_closed(mocker: MockerFixture) -> N
 
     assert result.notifications == []
     mock_edit.assert_called_once_with("org/repo", 10, "closed")
+    assert parent.state == "closed"
+
+
+def test_sync_resolved_child_cascades_parent_close_same_run(mocker: MockerFixture) -> None:
+    """An open child resolved this run closes, then its parent closes in the SAME run."""
+    edits: list[tuple[int, str]] = []
+    mocker.patch(
+        "security.issues.sync.gh_issue_edit_state",
+        side_effect=lambda repo, num, state: (edits.append((num, state)) or True),
+    )
+    parent = _issue_with_secmeta(10, {
+        "type": "parent", "rule_id": "R1", "repo": "org/repo",
+    })
+    child = _issue_with_secmeta(11, {
+        "type": "child", "rule_id": "R1", "fingerprint": "fp1", "repo": "org/repo",
+    })
+    issues = {10: parent, 11: child}
+
+    sync_alerts_and_issues({}, issues, dry_run=False)
+
+    assert (11, "closed") in edits
+    assert (10, "closed") in edits
+    assert child.state == "closed"
     assert parent.state == "closed"
 
 
@@ -1276,13 +1274,13 @@ def test_sync_creates_issue_above_threshold(
     mock_ensure.assert_called_once()
 
 
-def test_sync_adept_to_close_still_runs_for_below_threshold_alerts(
+def test_sync_resolved_close_still_runs_for_below_threshold_alerts(
     mocker: MockerFixture, sast_alert: Alert
 ) -> None:
-    """Adept-to-close logic uses all alerts regardless of min_severity threshold.
+    """Resolved-alert closure uses all alerts regardless of min_severity threshold.
 
     An existing open issue whose alert is below the threshold must NOT be
-    incorrectly marked adept-to-close just because it was filtered from creation.
+    incorrectly closed just because it was filtered from creation.
     """
     sast_alert.metadata.severity = "low"
     fp = sast_alert.alert_details.alert_hash
@@ -1291,14 +1289,14 @@ def test_sync_adept_to_close_still_runs_for_below_threshold_alerts(
         99,
         {"type": "child", "fingerprint": fp, "repo": "test-org/test-repo", "rule_id": "r1", "severity": "low"},
     )
-    mock_label = mocker.patch("security.issues.sync.gh_issue_add_labels")
+    mock_edit = mocker.patch("security.issues.sync.gh_issue_edit_state")
 
     sync_alerts_and_issues(
         {1: sast_alert}, {99: existing_child}, dry_run=False, min_severity="high"
     )
 
-    # The alert is still active, so adept-to-close must NOT have been applied.
-    mock_label.assert_not_called()
+    # The alert is still active, so the issue must NOT have been closed.
+    mock_edit.assert_not_called()
 
 
 def test_sync_unknown_severity_passes_at_min_low(

--- a/tests/security/services/test_label_checker.py
+++ b/tests/security/services/test_label_checker.py
@@ -76,8 +76,7 @@ def test_check_labels_some_missing(mocker: MockerFixture) -> None:
     mocker.patch.object(LabelChecker, "_fetch_labels", return_value=["scope:security", "epic"])
     missing = LabelChecker(REPO).check_labels()
     assert "type:tech-debt" in missing
-    assert "sec:adept-to-close" in missing
-    assert len(missing) == 2
+    assert len(missing) == 1
 
 
 def test_check_labels_all_missing(mocker: MockerFixture) -> None:


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request makes significant changes to how resolved security findings are handled in the AquaSec GitHub integration. The main update is that child issues for resolved findings are now automatically closed instead of being labeled for manual closure. All code, documentation, and tests have been updated to reflect this new behavior. Additionally, the obsolete `sec:adept-to-close` label and its handling have been removed, and new documentation has been added for manual waiver labels.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- GitHub issues now close automatically, after they disappear from AquaSec platform.
- New standard labels recommended sec:suppression and sec:false-positive for full security ticket lifecycle.

<!-- Add attached issue that this PR solves. -->
## Related
Closes #82 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Resolved security findings are now automatically closed when no longer detected (including orphaned/resolved child issues).
  - Added label-based guidance for suppression vs false-positive waivers, and reopening no longer affects human-managed waiver labels.
- **Documentation**
  - Updated security automation docs and prerequisites to match the new required label set and the closure lifecycle behavior.
- **Bug Fixes**
  - Resolved closure continues to run even when triggering alerts are below the configured severity threshold.
  - Parent issues can close automatically after all resolved child issues are closed.
- **Tests**
  - Updated/expanded sync and label-check coverage for the new closure flow.
- **Chores**
  - Minor CI/workflow adjustments to reflect updated AquaSec workflow references and pylint output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->