### PR TITLE
Feat: Adding fetched AquaSec JSON as workflow artifact.

### DIFF
--- a/.github/workflows/aquasec-scan.yml
+++ b/.github/workflows/aquasec-scan.yml
@@ -129,5 +129,12 @@ jobs:
           MIN_SEVERITY: ${{ inputs.min-severity }}
         run: |
           python3 org-workflows/src/security/main.py \
+            --scan-output aquasec_scan.json \
             ${{ inputs.dry-run && '--dry-run' || '' }} \
             ${{ inputs.verbose-logging && '--verbose' || '' }}
+
+      - name: Upload scan findings artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
+        with:
+          name: aquasec-night-scan
+          path: aquasec_scan.json

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -43,6 +43,12 @@ flowchart TD
 
 ---
 
+## Scan Artifact
+
+Every scan run uploads the fetched AquaSec findings as a workflow artifact named `aquasec-night-scan`, containing a single `aquasec_scan.json` file with all findings across every severity. It provides a full snapshot of the repository's current security state for monitoring purposes.
+
+---
+
 ## Key Benefits
 
 - **Zero manual triage**: New findings from AquaSec scans automatically become Issues with severity, context, and links to the affected code.

--- a/docs/security/security.md
+++ b/docs/security/security.md
@@ -45,7 +45,7 @@ flowchart TD
 
 ## Scan Artifact
 
-Every scan run uploads the fetched AquaSec findings as a workflow artifact named `aquasec-night-scan`, containing a single `aquasec_scan.json` file with all findings across every severity. It provides a full snapshot of the repository's current security state for monitoring purposes.
+When the scan step completes successfully, the fetched AquaSec findings are uploaded as a workflow artifact named `aquasec-night-scan`, containing a single `aquasec_scan.json` file with all findings across every severity. It provides a full snapshot of the repository's current security state for monitoring purposes.
 
 ---
 

--- a/src/core/helpers.py
+++ b/src/core/helpers.py
@@ -17,8 +17,10 @@
 """Pure utility functions"""
 
 import hashlib
+import json
 import re
 from datetime import datetime, timezone
+from typing import Any
 
 # Matches lines that start with 1-6 '#' followed by a space
 _HEADING_RE = re.compile(r"^(#{1,6}\s)", re.MULTILINE)
@@ -47,6 +49,12 @@ def iso_date(iso_dt: str | None) -> str:
 def sha256_hex(text: str) -> str:
     """Return the hex SHA-256 digest of *text*."""
     return hashlib.sha256(text.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+
+def write_json(path: str, data: Any) -> None:
+    """Write *data* to *path* as indented JSON (UTF-8)."""
+    with open(path, "w", encoding="utf-8") as file:
+        json.dump(data, file, indent=2)
 
 
 def normalize_path(path: str | None) -> str:

--- a/src/security/config.py
+++ b/src/security/config.py
@@ -47,6 +47,7 @@ class SecurityConfig:
     project_org: str = ""
     teams_webhook_url: str = ""
     min_severity: str = MIN_SEVERITY_DEFAULT
+    scan_output: str = ""
 
     @classmethod
     def load(cls, args: argparse.Namespace) -> "SecurityConfig":
@@ -77,6 +78,7 @@ class SecurityConfig:
             project_org=args.project_org or os.environ.get("PROJECT_ORG", ""),
             teams_webhook_url=args.teams_webhook_url or os.environ.get("TEAMS_WEBHOOK_URL", ""),
             min_severity=min_severity,
+            scan_output=args.scan_output,
         )
 
     def validate(self) -> None:

--- a/src/security/issues/sync.py
+++ b/src/security/issues/sync.py
@@ -377,7 +377,7 @@ def _handle_new_child_issue(
     if sync.dry_run:
         if parent_issue is not None:
             logging.info(
-                DRY_RUN_PREFIX + "Would create child issue for alert %d (rule: %s, severity: %s) linked to parent #%d",
+                DRY_RUN_PREFIX + "Would create child issue for alert %d (rule: %s, severity: %s)",
                 ctx.alert_number,
                 ctx.rule_id,
                 ctx.severity,

--- a/src/security/issues/sync.py
+++ b/src/security/issues/sync.py
@@ -381,7 +381,6 @@ def _handle_new_child_issue(
                 ctx.alert_number,
                 ctx.rule_id,
                 ctx.severity,
-                parent_issue.number,
             )
             sync.stats.children_linked += 1
         else:

--- a/src/security/main.py
+++ b/src/security/main.py
@@ -24,6 +24,7 @@ import logging
 import shutil
 
 from core.config import parse_runner_debug, setup_logging
+from core.helpers import write_json
 
 from security.alerts.aquasec_parser import AquaSecParser
 from security.constants import LOGGING_PREFIX
@@ -86,6 +87,11 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Teams Incoming Webhook URL. Falls back to $TEAMS_WEBHOOK_URL env var",
     )
     p.add_argument("--min-severity", default="", help="Minimum severity level for issue creation.")
+    p.add_argument(
+        "--scan-output",
+        default="",
+        help="Path to write the fetched AquaSec scan JSON. When omitted, no file is written.",
+    )
     p.add_argument("--dry-run", action="store_true", help="Do not write issues; only print intended actions")
     p.add_argument("--verbose", action="store_true", help="Verbose logs (also enabled by RUNNER_DEBUG=1)")
     return p.parse_args(argv)
@@ -125,6 +131,11 @@ def main(argv: list[str] | None = None) -> int:
     # Fetch scan findings
     fetcher = ScanFetcher(bearer_token, config.aqua_repository_id)
     scan_data = fetcher.fetch_findings()
+
+    # Write the raw scan JSON for monitoring when a path is provided
+    if config.scan_output:
+        write_json(config.scan_output, scan_data)
+        logger.info("%sScan findings written to %s", LOGGING_PREFIX, config.scan_output)
 
     # Parse findings
     parser = AquaSecParser(repo)

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 #
 
+import json
+
 import pytest
 
-from core.helpers import normalize_bullet_list, sanitize_markdown
+from core.helpers import normalize_bullet_list, sanitize_markdown, write_json
 
 
 # sanitize_markdown
@@ -96,3 +98,16 @@ def test_normalize_bullet_list_preserves_non_bullet_lines() -> None:
     text = "Some intro text\n- https://example.com\n  - https://other.com\nTrailing text"
     result = normalize_bullet_list(text)
     assert result == "Some intro text\n- https://example.com\n- https://other.com\nTrailing text"
+
+
+# write_json
+
+
+def test_write_json_writes_indented_content(tmp_path) -> None:
+    path = tmp_path / "aquasec_scan.json"
+    data = {"total": 2, "data": [{"a": 1}, {"b": 2}]}
+
+    write_json(str(path), data)
+
+    assert data == json.loads(path.read_text(encoding="utf-8"))
+    assert "\n  " in path.read_text(encoding="utf-8")

--- a/tests/core/test_helpers.py
+++ b/tests/core/test_helpers.py
@@ -110,4 +110,3 @@ def test_write_json_writes_indented_content(tmp_path) -> None:
     write_json(str(path), data)
 
     assert data == json.loads(path.read_text(encoding="utf-8"))
-    assert "\n  " in path.read_text(encoding="utf-8")

--- a/tests/security/test_config.py
+++ b/tests/security/test_config.py
@@ -35,6 +35,7 @@ def _make_args(**kwargs) -> argparse.Namespace:
         "project_org": "",
         "teams_webhook_url": "",
         "min_severity": "",
+        "scan_output": "",
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)

--- a/tests/security/test_main.py
+++ b/tests/security/test_main.py
@@ -67,6 +67,7 @@ def test_parse_args_defaults():
     assert args.issue_label == "scope:security"
     assert args.dry_run is False
     assert args.verbose is False
+    assert args.scan_output == ""
 
 
 def test_parse_args_all_flags():
@@ -77,6 +78,7 @@ def test_parse_args_all_flags():
         "--project-number", "42",
         "--project-org", "other-org",
         "--teams-webhook-url", "https://example.com/webhook",
+        "--scan-output", "aquasec_scan.json",
         "--dry-run",
         "--verbose",
     ])
@@ -86,6 +88,7 @@ def test_parse_args_all_flags():
     assert args.project_number == "42"
     assert args.project_org == "other-org"
     assert args.teams_webhook_url == "https://example.com/webhook"
+    assert args.scan_output == "aquasec_scan.json"
     assert args.dry_run is True
     assert args.verbose is True
 
@@ -126,6 +129,28 @@ def test_pipeline_calls_notify(mocker):
     mocks = _mock_pipeline(mocker)
     main(["--repo", REPO])
     mocks["notifier"].assert_called_once()
+
+
+# main - scan output
+
+
+def test_scan_output_writes_scan_data(mocker):
+    mocks = _mock_pipeline(mocker)
+    mocks["fetcher"].return_value.fetch_findings.return_value = {"total": 1, "data": [{"a": 1}]}
+    mock_write = mocker.patch("security.main.write_json")
+
+    main(["--repo", REPO, "--scan-output", "aquasec_scan.json"])
+
+    mock_write.assert_called_once_with("aquasec_scan.json", {"total": 1, "data": [{"a": 1}]})
+
+
+def test_scan_output_skipped_when_not_provided(mocker):
+    _mock_pipeline(mocker)
+    mock_write = mocker.patch("security.main.write_json")
+
+    main(["--repo", REPO])
+
+    mock_write.assert_not_called()
 
 
 def test_pipeline_call_order(mocker):


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview
This pull request adds the ability to output AquaSec scan findings as a JSON artifact and improves monitoring and traceability of security scans. It introduces a new `--scan-output` option to the security pipeline, writes scan results to a file when requested, uploads the artifact in CI, and documents the feature. Comprehensive tests are included to ensure correct behavior.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Scan run now uploads the fetched AquaSec findings as a workflow artifact named aquasec-night-scan, containing a single aquasec_scan.json file with all findings across every severity.

<!-- Add attached issue that this PR solves. -->
## Related
Closes #88 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional `--scan-output` option to save fetched scan findings as formatted JSON.
  * Nightly security scans now upload results as the `aquasec-night-scan` workflow artifact.
* **Documentation**
  * Documented the scan artifact and its included findings.
* **Bug Fixes**
  * Cleaned up dry-run logging when creating child issues under an existing parent.
* **Tests**
  * Added coverage for JSON output and optional scan-result saving.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->