### PR TITLE
fix(ci): re-pin publish-single-page-docs to a working upstream SHA

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -38,7 +38,9 @@ jobs:
           persist-credentials: false
 
       - name: Render and publish single-page docs
-        uses: AbsaOSS/knowledge-base/actions/publish-single-page-docs@679ec075cab1e1cdfb1140eedad7f2f80a5b683a
+        # Bumped by hand: the upstream repo publishes no tags or releases,
+        # so Dependabot cannot track this pin.
+        uses: AbsaOSS/knowledge-base/actions/publish-single-page-docs@fa935dc6ed1aae54d295e457424ee636914147c3
         with:
           # Which release the docs bundle is attached to
           release-tag: ${{ inputs.release-tag || github.event.release.tag_name }}


### PR DESCRIPTION
<!-- What problem does it solve or what feature does it add? -->
## Overview

The `Publish Docs` workflow added in #93 cannot run. It pins
`AbsaOSS/knowledge-base/actions/publish-single-page-docs` at
`679ec075cab1e1cdfb1140eedad7f2f80a5b683a`, and the action manifest at that
commit is invalid YAML — the `github-token` description holds an unquoted
`: ` (colon-space) inside backticks, which YAML reads as a nested mapping:

```yaml
  github-token:
    description: Token used to upload the release asset. Needs `contents: write`.
```

The runner therefore fails while loading the manifest, before any step runs.
This already happened in production: run `30910992670` on `master`
(`workflow_dispatch`) failed with

```
(Line: 26, Col: 73, Idx: 944): Mapping values are not allowed in this context.
System.ArgumentException: Unexpected type '' encountered while reading 'action manifest root'.
Failed to load AbsaOSS/knowledge-base/.../action.yml
```

Upstream fixed the manifest in `fa935dc6ed1aae54d295e457424ee636914147c3`
(`fix: quote colon-containing description in publish-single-page-docs action
manifest (#40)`), which also added action-manifest validation to the
knowledge-base CI so the class of bug should not recur there. This PR bumps
the pin to that commit.

A second point worth recording: the review discussion on #93 assumed the
`github-actions` Dependabot group would keep this pin fresh. It will not.
Dependabot resolves a pinned action SHA forward to the SHA of the newest
release or tag, and `AbsaOSS/knowledge-base` currently publishes **0 tags and
0 releases** — there is nothing to resolve to, so the pin would have sat on
the broken commit indefinitely. Pinning is still correct and stays; the
workflow now carries a two-line comment saying the bump is manual, so the
next reader does not inherit the same assumption.

Verification performed before pushing:

- `action.yml` at `fa935dc` fetched over the API (HTTP 200, so the action path
  exists at that SHA) and `yaml.safe_load` parses it cleanly; inputs are
  `docs`, `github-token`, `release-tag` as expected.
- `.github/workflows/publish_docs.yml` parses, and every `uses:` in it
  resolves to a bare 40-hex SHA ref.
- The `docs:` entry is byte-identical to #93 — slug `org-workflows-security`,
  icon `shield`, tags `[security, automation, aquasec, workflows]`, and the
  `release-tag` expression untouched.
- The action's renderer was run locally against this repository (the renderer
  `src/` is unchanged between the local clone and `fa935dc`; the only diff is
  `action.yml` plus the new CI job). It rendered
  `docs/security/security.md` → `org-workflows-security` with Mermaid support
  and packed a 753 KB bundle successfully. Output was written to a scratch
  directory, not into the repo.

Only the pinned SHA and the new comment change; nothing else in the workflow
was touched.

<!-- Summarize the key changes for release notes. -->
## Release Notes
- Fixed the `Publish Docs` workflow, which failed to start because the pinned
  `publish-single-page-docs` action revision contained an unparsable action
  manifest.
- Re-pinned `AbsaOSS/knowledge-base/actions/publish-single-page-docs` to
  `fa935dc6ed1aae54d295e457424ee636914147c3`, the upstream commit that fixes
  the manifest.
- Documented in the workflow that this pin is bumped manually, because the
  upstream repository publishes no tags or releases and Dependabot cannot
  track it.

<!-- Add attached issue that this PR solves. -->
## Related
Closes #94


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the documentation publishing workflow to use a newer pinned action version.
  * Added maintenance guidance for keeping the action reference current.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
